### PR TITLE
Use --exit-code flag in diff

### DIFF
--- a/scripts/dvm
+++ b/scripts/dvm
@@ -389,12 +389,12 @@ _dvm_needsupgrade() {
     return 0
   fi
 
-  git -C "$DVM_ROOT" diff origin
+  git -C "$DVM_ROOT" diff --exit-code origin/master
   if [[ $? -ne 0 ]]; then
-    # No diffs vs upstream.
-    return 0
+    # Has diffs vs upstream.
+    return 1
   fi
-  return 1
+  return 0
 }
 
 dvm_upgrade() {


### PR DESCRIPTION
Due to a reversed conditional, _dvm_needsupgrade always returned 1 even
when no upgrade was needed. This fixes the conditional and runs git diff
with the --exit-code option to ensure we get the same exit code
behaviour as regular diff; in other words, exit with 1 if there are
diffs and 0 otherwise.