### PR TITLE
dvm upgrade: check local vs upstream SHA

### DIFF
--- a/scripts/dvm
+++ b/scripts/dvm
@@ -389,8 +389,9 @@ _dvm_needsupgrade() {
     return 0
   fi
 
-  git -C "$DVM_ROOT" diff --exit-code origin/master > /dev/null
-  if [[ $? -eq 0 ]]; then
+  local local_sha="$(git -C "$DVM_ROOT" rev-parse HEAD)"
+  local remote_sha="$(git -C "$DVM_ROOT" rev-parse origin/master)"
+  if [[ "$local_sha" == "$remote_sha" ]]; then
     # No diffs vs upstream.
     return 0
   fi


### PR DESCRIPTION
in _dvm_needsupgrade, rather than check for diffs, check whether the
local/remote SHA match. This catches cases where, for example, a commit
was landed, then reverted upstream.

In terms of user-visible functionality, the end result is the same, but
this helps keep up to date with upstream dvm. This is particularly
helpful in cases where the user has local patches applied, by forcing
them to deal with any conflicts soon after the upstream commit lands,
rather than months (or even years) down the road, when the next dvm
change lands.