### PR TITLE
Added bash completion and fzf support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 *~
 
 # DVM
-darts
+darts/
+cache/
+environments/

--- a/scripts/bash-completion.sh
+++ b/scripts/bash-completion.sh
@@ -1,0 +1,72 @@
+# Setup bash completion
+_dvm_completions() {
+  local CURRENT_WORD="${COMP_WORDS[COMP_CWORD]}"
+  
+  if [[ "$COMP_CWORD" == 0 ]]; then
+    COMPREPLY=($(compgen -W "dvm" -- "$CURRENT_WORD"))
+    return
+  fi
+  if [[ "$COMP_CWORD" == 1 ]]; then
+    COMPREPLY=($(compgen -W "alias implode install list listall upgrade use version" -- "$CURRENT_WORD"))
+    return
+  fi
+  
+  case "${COMP_WORDS[1]}" in
+    # dvm alias
+    alias)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "create update delete list" -- "$CURRENT_WORD"))
+      fi
+      ;;
+    
+    # dvm implode
+    implode)
+      ;;
+    
+    # dvm install
+    install)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "$(dvm listall)" -- "$CURRENT_WORD"))
+      fi
+      ;;
+    
+    # dvm list
+    list)
+      ;;
+    
+    # dvm listall
+    listall)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "--dev --beta" -- "$CURRENT_WORD"))
+      fi
+      ;;
+    
+    # dvm upgrade
+    upgrade)
+      ;;
+    
+    # dvm use
+    use)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "$(dvm list) --default" -- "$CURRENT_WORD"))
+      fi
+      if [[ "$COMP_CWORD" == 3 ]]; then
+        if [[ "${COMP_WORDS[2]}" == '--default' ]]; then
+          COMPREPLY=($(compgen -W "$(dvm list)" -- "$CURRENT_WORD"))
+        else
+          COMPREPLY=($(compgen -W "--default" -- "$CURRENT_WORD"))
+        fi
+      fi
+      ;; 
+    
+    # dvm version
+    version)
+      ;;
+
+    # Others don't work!
+    *)
+      ;;
+  esac
+} && complete -F _dvm_completions dvm
+
+

--- a/scripts/dvm
+++ b/scripts/dvm
@@ -539,79 +539,9 @@ dvm() {
   esac
 }
 
-
-_dvm_completions() {
-  local CURRENT_WORD="${COMP_WORDS[COMP_CWORD]}"
-  
-  if [[ "$COMP_CWORD" == 0 ]]; then
-    COMPREPLY=($(compgen -W "dvm" -- "$CURRENT_WORD"))
-    return
-  fi
-  if [[ "$COMP_CWORD" == 1 ]]; then
-    COMPREPLY=($(compgen -W "alias implode install list listall upgrade use version" -- "$CURRENT_WORD"))
-    return
-  fi
-  
-  case "${COMP_WORDS[1]}" in
-    # dvm alias
-    alias)
-      if [[ "$COMP_CWORD" == 2 ]]; then
-        COMPREPLY=($(compgen -W "create update delete list" -- "$CURRENT_WORD"))
-      fi
-      ;;
-    
-    # dvm implode
-    implode)
-      ;;
-    
-    # dvm install
-    install)
-      if [[ "$COMP_CWORD" == 2 ]]; then
-        COMPREPLY=($(compgen -W "$(_dvm_list_repo 'stable')" -- "$CURRENT_WORD"))
-      fi
-      ;;
-    
-    # dvm list
-    list)
-      ;;
-    
-    # dvm listall
-    listall)
-      if [[ "$COMP_CWORD" == 2 ]]; then
-        COMPREPLY=($(compgen -W "--dev --beta" -- "$CURRENT_WORD"))
-      fi
-      ;;
-    
-    # dvm upgrade
-    upgrade)
-      ;;
-    
-    # dvm use
-    use)
-      if [[ "$COMP_CWORD" == 2 ]]; then
-        COMPREPLY=($(compgen -W "$(_dvm_list) --default" -- "$CURRENT_WORD"))
-      fi
-      if [[ "$COMP_CWORD" == 3 ]]; then
-        if [[ "${COMP_WORDS[2]}" == '--default' ]]; then
-          COMPREPLY=($(compgen -W "$(_dvm_list)" -- "$CURRENT_WORD"))
-        else
-          COMPREPLY=($(compgen -W "--default" -- "$CURRENT_WORD"))
-        fi
-      fi
-      ;; 
-    
-    # dvm version
-    version)
-      ;;
-
-    # Others don't work!
-    *)
-      ;;
-  esac
-}
-
-# Setup bash completion
-complete -F _dvm_completions dvm
+if [ -n "${BASH_VERSION}" ]; then
+  . "$DVM_ROOT/scripts/bash-completion.sh"
+fi
 
 if [[ -e "$DVM_ROOT/environments/default" ]]; then
   . "$DVM_ROOT/environments/default"

--- a/scripts/dvm
+++ b/scripts/dvm
@@ -25,6 +25,7 @@ _dvm_usage() {
 _dvm_create_dirs() {
   mkdir -p "$DVM_ROOT/darts" > /dev/null 2>&1
   mkdir -p "$DVM_ROOT/environments" > /dev/null 2>&1
+  mkdir -p "$DVM_ROOT/cache" > /dev/null 2>&1
 }
 
 # Removes $1 from PATH.
@@ -50,6 +51,22 @@ _dvm_doctor() {
     echo "  RedHat/Fedora: sudo dnf install unzip"
     echo "  OpenSUSE:      sudo zypper install unzip"
     echo "  Arch/Manjaro:  sudo pacman -S unzip"
+    echo "  Mac OS:        brew install unzip"
+    return 1
+  fi
+}
+
+_dvm_check_fzf() {
+  if [[ ! -x "$(which fzf)" ]]; then
+    echo "ERROR: dvm requires the 'fzf' tool, which was not found."
+    echo "To install fzf:"
+    echo "  Debian/Ubuntu: sudo apt install fzf"
+    echo "  RedHat/Fedora: sudo dnf install fzf"
+    echo "  OpenSUSE:      sudo zypper install fzf"
+    echo "  Arch/Manjaro:  sudo pacman -S fzf"
+    echo "  Mac OS:        brew install fzf"
+    echo ""
+    echo "See: https://github.com/junegunn/fzf#installation"
     return 1
   fi
 }
@@ -58,7 +75,7 @@ _dvm_alias_usage() {
   echo "usage: dvm alias <create|update|delete|list> [<args>]"
 }
 
-dvm_alias_list() {
+_dvm_alias_list() {
   find "$DVM_ROOT/darts" -maxdepth 1 ! -path "$DVM_ROOT/darts" -type l -exec basename "{}" \; | sort
 }
 
@@ -85,7 +102,7 @@ _dvm_alias_set() {
   fi
 }
 
-dvm_alias_update() {
+_dvm_alias_update() {
   if [[ $# < 2 || "$2" == "--path" && $# < 3 ]]; then
     echo "usage: dvm alias update <alias> [--path] <version>"
     return 1
@@ -100,7 +117,7 @@ dvm_alias_update() {
   _dvm_alias_set "$@"
 }
 
-dvm_alias_create() {
+_dvm_alias_create() {
   if [[ $# < 2 || "$2" == "--path" && $# < 3 ]]; then
     echo "usage: dvm alias create <alias> [--path] <version>"
     return 1
@@ -118,7 +135,7 @@ dvm_alias_create() {
   _dvm_alias_set "$@"
 }
 
-dvm_alias_delete() {
+_dvm_alias_delete() {
   if [[ $# < 1 ]]; then
     echo "usage: dvm alias delete <alias>"
     return 1
@@ -130,7 +147,7 @@ dvm_alias_delete() {
   rm -f -- "$DVM_ROOT/darts/$1"
 }
 
-dvm_alias() {
+_dvm_alias() {
   if [[ $# < 1 ]]; then
     _dvm_alias_usage
     return 1
@@ -139,16 +156,16 @@ dvm_alias() {
   shift
   case $cmd in
     create)
-      dvm_alias_create "$@"
+      _dvm_alias_create "$@"
       ;;
     delete)
-      dvm_alias_delete "$@"
+      _dvm_alias_delete "$@"
       ;;
     list)
-      dvm_alias_list "$@"
+      _dvm_alias_list "$@"
       ;;
     update)
-      dvm_alias_update "$@"
+      _dvm_alias_update "$@"
       ;;
     *)
       _dvm_alias_usage
@@ -157,14 +174,27 @@ dvm_alias() {
   esac
 }
 
-dvm_use() {
+_dvm_use() {
   if [[ $# < 1 ]]; then
+    _dvm_check_fzf || return 1
+
+    local version=$(_dvm_list | fzf --no-multi --tac)
+    local default=''
+  elif [[ $# == 1 ]] && [[ "$1" == "--default" ]]; then
+    _dvm_check_fzf || exit 1;
+
+    local version=$(_dvm_list | fzf --no-multi --tac)
+    local default="--default"
+  elif [[ $# == 2 ]] && [[ "$1" == "--default" ]]; then
+    local version="$2"
+    local default="$1"
+  elif [[ $# > 2 ]]; then
     echo "usage: dvm use <version> [--default]"
     return 1
+  else
+    local version="$1"
+    local default="$2"
   fi
-
-  local version=$1
-  local default=$2
   shift
 
   if [[ ! -e "$DVM_ROOT/darts/$version" ]]; then
@@ -183,23 +213,29 @@ dvm_use() {
   _dvm_path_prepend "$DVM_ROOT/darts/$version/bin"
 }
 
-dvm_list() {
+_dvm_list() {
   find "$DVM_ROOT/darts" -maxdepth 1 ! -path "$DVM_ROOT/darts" -type d \
       -exec basename "{}" \; | sort -V
 }
 
 _dvm_list_repo() {
-  local channel=$1
+  local channel="$1"
   local api_uri="https://www.googleapis.com/storage/v1/b/dart-archive/o"
   local query="prefix=channels/$channel/release/&delimiter=/"
-  curl -s "$api_uri?$query" | \
+  local cache_file="$DVM_ROOT/cache/versions-$channel"
+  if [ ! -f "$cache_file" ] || [[ $(($(date +%s) - $(date -r "$cache_file" +%s))) -gt 300 ]]; then
+    curl -s "$api_uri?$query" | \
       grep "channels/$channel/release/" | \
       sed -e "s@.*/$channel/release/@@;s@/.*@@" | \
       grep -v "^[0-9]*$" | \
-      sort -V
+      sort -V | \
+      tee "$cache_file"
+  else
+    cat "$cache_file"
+  fi
 }
 
-dvm_listall() {
+_dvm_listall() {
   if [[ "$1" == "--dev" ]]; then
     _dvm_list_repo "dev"
   elif [[ "$1" == "--beta" ]]; then
@@ -254,10 +290,16 @@ _dvm_dartium_arch() {
   fi
 }
 
-dvm_install() {
+_dvm_install() {
   if [[ $# < 1 ]]; then
+    _dvm_check_fzf || return 1
+
+    local version=$(_dvm_listall | fzf --no-multi --tac)
+  elif [[ $# > 1 ]]; then
     echo "usage: dvm install <version>"
     return 1
+  else
+    local version="$1"
   fi
 
   curl=$(which curl)
@@ -266,7 +308,6 @@ dvm_install() {
     return 1
   fi
 
-  local version=$1
   shift
 
   if [[ -d "$DVM_ROOT/darts/$version" ]]; then
@@ -398,7 +439,7 @@ _dvm_needsupgrade() {
   return 1
 }
 
-dvm_upgrade() {
+_dvm_upgrade() {
   # Abort if there are local diffs that aren't checked in.
   local diffs="$(git -C "$DVM_ROOT" status --porcelain=v1 2>/dev/null)"
   if [[ -n "$diffs" ]]; then
@@ -426,11 +467,11 @@ dvm_upgrade() {
   return 0
 }
 
-dvm_version() {
+_dvm_version() {
   echo "Dart Version Manager version $DVM_VERSION installed at $DVM_ROOT"
 }
 
-dvm_implode() {
+_dvm_implode() {
   echo "This will delete dvm and all installed versions."
   echo -n "Are you sure? "
   read yn
@@ -469,34 +510,108 @@ dvm() {
   shift
   case $cmd in
     alias)
-      dvm_alias "$@"
+      _dvm_alias "$@"
       ;;
     implode)
-      dvm_implode "$@"
+      _dvm_implode "$@"
       ;;
     install)
-      dvm_install "$@"
+      _dvm_install "$@"
       ;;
     list)
-      dvm_list "$@"
+      _dvm_list "$@"
       ;;
     listall)
-      dvm_listall "$@"
+      _dvm_listall "$@"
       ;;
     upgrade)
-      dvm_upgrade "$@"
+      _dvm_upgrade "$@"
       ;;
     use)
-      dvm_use "$@"
+      _dvm_use "$@"
       ;;
     version)
-      dvm_version "$@"
+      _dvm_version "$@"
       ;;
     *)
       _dvm_usage
       ;;
   esac
 }
+
+
+_dvm_completions() {
+  local CURRENT_WORD="${COMP_WORDS[COMP_CWORD]}"
+  
+  if [[ "$COMP_CWORD" == 0 ]]; then
+    COMPREPLY=($(compgen -W "dvm" -- "$CURRENT_WORD"))
+    return
+  fi
+  if [[ "$COMP_CWORD" == 1 ]]; then
+    COMPREPLY=($(compgen -W "alias implode install list listall upgrade use version" -- "$CURRENT_WORD"))
+    return
+  fi
+  
+  case "${COMP_WORDS[1]}" in
+    # dvm alias
+    alias)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "create update delete list" -- "$CURRENT_WORD"))
+      fi
+      ;;
+    
+    # dvm implode
+    implode)
+      ;;
+    
+    # dvm install
+    install)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "$(_dvm_list_repo 'stable')" -- "$CURRENT_WORD"))
+      fi
+      ;;
+    
+    # dvm list
+    list)
+      ;;
+    
+    # dvm listall
+    listall)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "--dev --beta" -- "$CURRENT_WORD"))
+      fi
+      ;;
+    
+    # dvm upgrade
+    upgrade)
+      ;;
+    
+    # dvm use
+    use)
+      if [[ "$COMP_CWORD" == 2 ]]; then
+        COMPREPLY=($(compgen -W "$(_dvm_list) --default" -- "$CURRENT_WORD"))
+      fi
+      if [[ "$COMP_CWORD" == 3 ]]; then
+        if [[ "${COMP_WORDS[2]}" == '--default' ]]; then
+          COMPREPLY=($(compgen -W "$(_dvm_list)" -- "$CURRENT_WORD"))
+        else
+          COMPREPLY=($(compgen -W "--default" -- "$CURRENT_WORD"))
+        fi
+      fi
+      ;; 
+    
+    # dvm version
+    version)
+      ;;
+
+    # Others don't work!
+    *)
+      ;;
+  esac
+}
+
+# Setup bash completion
+complete -F _dvm_completions dvm
 
 if [[ -e "$DVM_ROOT/environments/default" ]]; then
   . "$DVM_ROOT/environments/default"


### PR DESCRIPTION
This adds:
 * Bash completion 
    * Renames internal functions to be prefixed `_` so they don't show up in `dv<tab><tab>`
    * `dvm use <tab><tab>` will show list of installed versions and `--default`
    * `dvm use --default <tab><tab>` will show list of installed versions
    * `dvm install <tab><tab>` will show list of stable versions (this seems like the thing most used will need).
 * Fuzzy matching with `fzf`
    * `dvm install` will open `fzf` with stable versions
    * `dvm use` will option `fzf` with installed versions
    * `dvm use --default` will option `fzf` with installed versions

To make bash completion and fuzzy matching fast, the list of versions for stable, beta and dev will be saved to:
 * `$DVM_ROOT/cache/versions-stable`
 * `$DVM_ROOT/cache/versions-beta`
 * `$DVM_ROOT/cache/versions-dev`

If older than 5 minutes the list of versions will be refreshed. According to `man date` this should work on Mac OS too, but I only tested it on Linux.


----

warning: it's entirely possible that I made a typo in some of this code, I renamed quite a few things -- and I have yet to figure out what `dvm alias` is good for :see_no_evil: 
