### PR TITLE
Allow user-written extension functions

### DIFF
--- a/scripts/dvm
+++ b/scripts/dvm
@@ -493,7 +493,11 @@ dvm() {
       dvm_version "$@"
       ;;
     *)
-      _dvm_usage
+      if [[ $(type -t dvm_$cmd) == "function" ]]; then
+        dvm_$cmd "$@"
+      else
+        _dvm_usage
+      fi
       ;;
   esac
 }


### PR DESCRIPTION
Allows `dvm foo` to dispatch to `dvm_foo` for any name "foo", as long as `dvm_foo` is a shell function.
This allows users to introduce their own helpers and extensions and use them consistently with the built-in functions.